### PR TITLE
Update target for “Learn more” links

### DIFF
--- a/src/widgets/pages/welcome.rs
+++ b/src/widgets/pages/welcome.rs
@@ -167,7 +167,7 @@ impl WelcomePageWidget {
         container.add(&text);
 
         let welcome_url = format!(
-            "<a href=\"https://www.endlessos.org/post/endless-os-5-is-coming\">{}</a>",
+            "<a href=\"https://support.endlessos.org/endless-os/release-notes/5\">{}</a>",
             gettext("Learn more about Endless OS 5 on our website")
         );
         let url_label = gtk::LabelBuilder::new()

--- a/src/widgets/window.rs
+++ b/src/widgets/window.rs
@@ -85,7 +85,7 @@ impl Window {
             gettext("That's it. Have a nice day!"),
             gettext("To get more advice and tips, see the Help app."),
             Some(format!(
-                "<a href=\"https://www.endlessos.org/post/endless-os-5-is-coming\">{}</a>",
+                "<a href=\"https://support.endlessos.org/endless-os/release-notes/5\">{}</a>",
                 gettext("Learn more about Endless OS 5 on our website")
             )),
         );


### PR DESCRIPTION
We now have high-level release notes for Endless OS 5, based on that blog post.

https://phabricator.endlessm.com/T34450
