### PR TITLE
Apply downstream patches for gnome-tour 43

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,0 +1,8 @@
+[main]
+host = https://www.transifex.com
+
+[o:endless-os:p:gnome-tour:r:app]
+file_filter = po/<lang>.po
+source_file = po/gnome-tour.pot
+source_lang = en
+type        = PO

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,9 +399,9 @@ dependencies = [
 
 [[package]]
 name = "gtk4"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64f0c2a3d80e899dc3febddad5bac193ffcf74a0fd7e31037f30dd34d6f7396"
+checksum = "4e8ae5aef2793bc3551b5e5e3fa062a5de54bb1eccf10dfa4effe9e4384fbbbc"
 dependencies = [
  "bitflags",
  "cairo-rs",
@@ -422,9 +422,9 @@ dependencies = [
 
 [[package]]
 name = "gtk4-macros"
-version = "0.4.8"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fafbcc920af4eb677d7d164853e7040b9de5a22379c596f570190c675d45f7a7"
+checksum = "6aba0b544e91a753068e279e99d34e9624b8cfd26282167024c8a5773b8a826c"
 dependencies = [
  "anyhow",
  "proc-macro-crate",

--- a/data/resources/style.css
+++ b/data/resources/style.css
@@ -33,14 +33,14 @@ window .titlebar button {
   .page:nth-child(3) {  }  /* customize */
   /* .page:nth-child(4) { background: linear-gradient(to right, #e66100, #c64600); }  workspaces */
 
-  .page:nth-child(5) { /* up down */
+  .page:nth-child(3) { /* up down */
     background: url('/org/gnome/Tour/hand-fg.svg'),
                 url('/org/gnome/Tour/updown-bg.svg');
     background-repeat: no-repeat;
     background-position: center 30%;
     animation: up-and-down 2s ease-in-out infinite alternate;
     }
-  .page:nth-child(6) {   /* left right */
+  .page:nth-child(4) {   /* left right */
     background: url('/org/gnome/Tour/hand-fg.svg'),
                 url('/org/gnome/Tour/leftright-bg.svg');
     background-repeat: no-repeat;

--- a/data/resources/ui/window.ui
+++ b/data/resources/ui/window.ui
@@ -20,20 +20,6 @@
         </child>
         <child>
           <object class="ImagePageWidget">
-            <property name="resource-uri">/org/gnome/Tour/search.svg</property>
-            <property name="head" translatable="yes">Just Type to Search</property>
-            <property name="body" translatable="yes">Type in the overview to search. Launch apps, find things.</property>
-          </object>
-        </child>
-        <child>
-          <object class="ImagePageWidget">
-            <property name="resource-uri">/org/gnome/Tour/workspaces.svg</property>
-            <property name="head" translatable="yes">Keep on Top with Workspaces</property>
-            <property name="body" translatable="yes">Easily organize windows with the workspaces view.</property>
-          </object>
-        </child>
-        <child>
-          <object class="ImagePageWidget">
             <property name="resource-uri">/org/gnome/Tour/blank.svg</property>
             <property name="head" translatable="yes">Up/Down for the Overview</property>
             <property name="body" translatable="yes">On a touchpad, use three-finger vertical swipes. Try it!</property>

--- a/data/resources/ui/window.ui
+++ b/data/resources/ui/window.ui
@@ -39,6 +39,8 @@
             <property name="resource-uri">/org/gnome/Tour/ready-to-go.svg</property>
             <property name="head" translatable="yes">That's it. Have a nice day!</property>
             <property name="body" translatable="yes">To get more advice and tips, see the Help app.</property>
+            <property name="extra" translatable="yes">Learn more about Endless OS 5 on our website</property>
+            <property name="extra-uri">https://support.endlessos.org/endless-os/release-notes/5</property>"
             <style>
               <class name="last-page" />
             </style>

--- a/data/resources/ui/window.ui
+++ b/data/resources/ui/window.ui
@@ -9,6 +9,8 @@
           <object class="ImagePageWidget" id="welcome_page">
             <property name="resource-uri">/org/gnome/Tour/welcome.svg</property>
             <property name="head" translatable="yes">Start the Tour</property>
+            <property name="extra" translatable="yes">Learn more about Endless OS 5 on our website</property>
+            <property name="extra-uri">https://support.endlessos.org/endless-os/release-notes/5</property>
           </object>
         </child>
         <child>

--- a/src/meson.build
+++ b/src/meson.build
@@ -31,8 +31,6 @@ else
   message('Building in debug mode')
 endif
 
-cargo_env = [ 'CARGO_HOME=' + meson.project_build_root() / 'cargo-home' ]
-
 cargo_build = custom_target(
   'cargo-build',
   build_by_default: true,
@@ -43,8 +41,6 @@ cargo_build = custom_target(
   install_dir: bindir,
   depends: resources,
   command: [
-    'env',
-    cargo_env,
     cargo, 'build',
     cargo_options,
     '&&',


### PR DESCRIPTION
https://phabricator.endlessm.com/T35075

-----

+ 67827a3066509435f61e2983d6afda27d0102051 Update gtk4 in Cargo.lock
Added. Looks like we need this if we want this release to build.

+ b5cc05a6bf871d0e699e85d93f69e21a479c3a04 cargo: Quote a possibly-empty variable
Dropped.

+ 2c93924ea420c10789dc5e232f610dd09e721591 Remove search & first workspace page
Rebased, accounting for changes in 626d7733.

+ 84ba2a6159e9683263aae7532c1631215ef4d44c welcome: Add link label to release notes
Rebased, also accounting for changes in 626d7733.

+ c59795e583438db99aafd0e616c8c2a3d7b2040d window: Add link label to release notes on last page
Rebased. Much simpler now.

+ a9d621ea091a997352c4c9fbd6749cac1c9ac937 Integrate Transifex translation infrastructure
Kept as-is.

+ 8ad95e3d6c6b6ce755b627e54ea33b40999afbb6 Update target for “Learn more” links
Squashed into 84ba2a61 and c59795e5.
