### PR TITLE
Remove links to Endless OS 5 release notes

### DIFF
--- a/data/resources/ui/window.ui
+++ b/data/resources/ui/window.ui
@@ -9,8 +9,6 @@
           <object class="ImagePageWidget" id="welcome_page">
             <property name="resource-uri">/org/gnome/Tour/welcome.svg</property>
             <property name="head" translatable="yes">Start the Tour</property>
-            <property name="extra" translatable="yes">Learn more about Endless OS 5 on our website</property>
-            <property name="extra-uri">https://support.endlessos.org/endless-os/release-notes/5</property>
           </object>
         </child>
         <child>

--- a/data/resources/ui/window.ui
+++ b/data/resources/ui/window.ui
@@ -39,8 +39,6 @@
             <property name="resource-uri">/org/gnome/Tour/ready-to-go.svg</property>
             <property name="head" translatable="yes">That's it. Have a nice day!</property>
             <property name="body" translatable="yes">To get more advice and tips, see the Help app.</property>
-            <property name="extra" translatable="yes">Learn more about Endless OS 5 on our website</property>
-            <property name="extra-uri">https://support.endlessos.org/endless-os/release-notes/5</property>"
             <style>
               <class name="last-page" />
             </style>

--- a/src/widgets/image_page.rs
+++ b/src/widgets/image_page.rs
@@ -14,8 +14,6 @@ mod imp {
         pub(super) resource_uri: OnceCell<String>,
         pub(super) head: OnceCell<String>,
         pub(super) body: RefCell<String>,
-        pub(super) extra: RefCell<String>,
-        pub(super) extra_uri: RefCell<String>,
         pub(super) picture: gtk::Picture,
     }
 
@@ -82,22 +80,6 @@ mod imp {
                 .build();
             container.append(&body_label);
 
-            let extra_button = gtk::LinkButton::builder().margin_top(12).build();
-            obj.bind_property("extra", &extra_button, "label")
-                .flags(glib::BindingFlags::SYNC_CREATE)
-                .build();
-            obj.bind_property("extra-uri", &extra_button, "uri")
-                .flags(glib::BindingFlags::SYNC_CREATE)
-                .build();
-            obj.bind_property("extra", &extra_button, "visible")
-                .flags(glib::BindingFlags::SYNC_CREATE)
-                .transform_to(|_, value: &glib::Value| {
-                    let extra = value.get::<Option<String>>().unwrap()?;
-                    Some((!extra.is_empty()).to_value())
-                })
-                .build();
-            container.append(&extra_button);
-
             obj.append(&clamp);
             self.parent_constructed(obj);
         }
@@ -113,12 +95,6 @@ mod imp {
                         .build(),
                     ParamSpecString::builder("body")
                         .flags(ParamFlags::READWRITE | ParamFlags::CONSTRUCT)
-                        .build(),
-                    ParamSpecString::builder("extra")
-                        .flags(ParamFlags::READWRITE | ParamFlags::CONSTRUCT_ONLY)
-                        .build(),
-                    ParamSpecString::builder("extra-uri")
-                        .flags(ParamFlags::READWRITE | ParamFlags::CONSTRUCT_ONLY)
                         .build(),
                 ]
             });
@@ -141,16 +117,6 @@ mod imp {
                         self.body.replace(body);
                     }
                 }
-                "extra" => {
-                    if let Some(extra) = value.get::<Option<String>>().unwrap() {
-                        self.extra.replace(extra);
-                    }
-                }
-                "extra-uri" => {
-                    if let Some(extra_uri) = value.get::<Option<String>>().unwrap() {
-                        self.extra_uri.replace(extra_uri);
-                    }
-                }
                 _ => unimplemented!(),
             }
         }
@@ -160,8 +126,6 @@ mod imp {
                 "resource-uri" => self.resource_uri.get().to_value(),
                 "head" => self.head.get().to_value(),
                 "body" => self.body.borrow().to_value(),
-                "extra" => self.extra.borrow().to_value(),
-                "extra-uri" => self.extra_uri.borrow().to_value(),
                 _ => unimplemented!(),
             }
         }
@@ -176,19 +140,11 @@ glib::wrapper! {
 }
 
 impl ImagePageWidget {
-    pub fn new(
-        resource_uri: &str,
-        head: String,
-        body: String,
-        extra: String,
-        extra_uri: String,
-    ) -> Self {
+    pub fn new(resource_uri: &str, head: String, body: String) -> Self {
         glib::Object::new::<Self>(&[
             ("resource-uri", &resource_uri),
             ("head", &head),
             ("body", &body),
-            ("extra", &extra),
-            ("extra-uri", &extra_uri),
         ])
         .unwrap()
     }


### PR DESCRIPTION
This link points to the Endless OS 5 release notes, and hardcodes the
string “Endless OS 5”.

We added this link because the changes between Endless OS 4 and 5 were
so dramatic.

The tour is offered when the user logs in and org.gnome.shell
welcome-dialog-last-shown-version is set to a value lower than 40.beta.
Its default value is empty string, so in practice this means the tour i
offered in two cases:

1. New user account
2. Upgrade from Endless OS 4.

It is vanishingly unlikely that a user upgrading from Endless OS 4 will
be offered the tour for the first time in Endless OS 6. They would have
had to have performed the 4 → 5 upgrade, then, without logging into
their user account, upgraded from 5 to 6. So there is no need to tell
them about the 4 → 5 transition.

This leaves new users, who similarly do not need to be told about the 4
→ 5 transition.

https://phabricator.endlessm.com/T35336